### PR TITLE
MDS-382 | Update code given the latest IF schema changes

### DIFF
--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/PayeEntrySpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/PayeEntrySpec.scala
@@ -110,12 +110,12 @@ class PayeEntrySpec extends UnitSpec {
           |    },
           |    "studentLoan": {
           |        "planType": "02",
-          |        "repaymentsInPayPeriod": 88478.16,
-          |        "repaymentsYTD": 545.52
+          |        "repaymentsInPayPeriod": 88478,
+          |        "repaymentsYTD": 545
           |    },
           |    "postGradLoan": {
-          |        "repaymentsInPayPeriod": 15636.22,
-          |        "repaymentsYTD": 46849.26
+          |        "repaymentsInPayPeriod": 15636,
+          |        "repaymentsYTD": 46849
           |    }
           |}
           |""".stripMargin
@@ -154,7 +154,7 @@ class PayeEntrySpec extends UnitSpec {
 
   private def createValidBenefits() = Benefits(Some(506328.1), Some(246594.83))
 
-  private def createValidStudentLoan() = StudentLoan(Some("02"), Some(88478.16), Some(545.52))
+  private def createValidStudentLoan() = StudentLoan(Some("02"), Some(88478), Some(545))
 
-  private def createValidPostGradLoan() = PostGradLoan(Some(15636.22), Some(46849.26))
+  private def createValidPostGradLoan() = PostGradLoan(Some(15636), Some(46849))
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/PostGradLoanSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/PostGradLoanSpec.scala
@@ -23,16 +23,16 @@ import uk.gov.hmrc.individualsifapistub.domain.IncomePaye._
 
 class PostGradLoanSpec extends UnitSpec {
 
-  val validPostGradLoan = PostGradLoan(Some(1588498.34), Some(2217757.33))
-  val invalidPostGradLoan = PostGradLoan(Some(9999999999.99 + 1), Some(9999999999.99 + 1))
+  val validPostGradLoan = PostGradLoan(Some(15884), Some(22177))
+  val invalidPostGradLoan = PostGradLoan(Some(99999 + 1), Some(-1))
 
   "PostGradLoan" should {
     "Write to json" in {
       val expectedJson = Json.parse(
         """
           |{
-          |  "repaymentsInPayPeriod": 1588498.34,
-          |  "repaymentsYTD": 2217757.33
+          |  "repaymentsInPayPeriod": 15884,
+          |  "repaymentsYTD": 22177
           |}
           |""".stripMargin
       )

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/StudentLoanSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/income/StudentLoanSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.individualsifapistub.domain.IncomePaye._
 
 class StudentLoanSpec extends UnitSpec {
   val validStudentLoan = StudentLoan(Some("01"),Some(100), Some(100))
-  val invalidStudentLoan = StudentLoan(Some("NotValid"),Some(9999999999.99 + 1), Some(9999999999.99 + 1))
+  val invalidStudentLoan = StudentLoan(Some("NotValid"),Some(99999 + 1), Some(-1))
 
   "Student Loan" should {
     "WriteToJson" in {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/testUtils/IncomePayeHelpers.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/testUtils/IncomePayeHelpers.scala
@@ -60,7 +60,7 @@ trait IncomePayeHelpers {
 
   private def createValidBenefits() = Benefits(Some(506328.1), Some(246594.83))
 
-  private def createValidStudentLoan() = StudentLoan(Some("02"), Some(88478.16), Some(545.52))
+  private def createValidStudentLoan() = StudentLoan(Some("02"), Some(88478), Some(545))
 
-  private def createValidPostGradLoan() = PostGradLoan(Some(15636.22), Some(46849.26))
+  private def createValidPostGradLoan() = PostGradLoan(Some(15636), Some(46849))
 }


### PR DESCRIPTION
The changes since version 1.2.0 are:
 
```
1) Documentation - wording changes to make clear that for Self Assessment a tax year range is used and for PAYE a date range is used
2) Amended the type 'payeWholeUnitsPaymentType' and applied it to the PAYE properties 'repaymentsInPayPeriod' (for Student Loans and Post Grad loans)
3) Added the type 'payeWholeUnitsPositivePaymentType' and applied it to the PAYE properties 'repaymentsYTD' (for Student Loans and Post Grad loans)
4) Removed the "uniqueItems" constraint from the SA "sa" and "returnList" arrays, and from the PAYE "paye" array. This to allow duplicate array entries (anonymous objects) as a result of a consumer's filtering request in the 'fields' query parameter
5) Removed the fractional seconds from the example PAYE properties that use the JSON date-time format
6) Amended the example PAYE response properties 'repaymentsInPayPeriod' and 'repaymentsYTD' to make them valid
7) Amended several example response fractional values (purely to avoid warnings in Stoplight Studio v2.1.0)
```
 
Highlighted changes 2, 3, and 4 are the functional ones related to the mistakes found with the monetary properties within the “studentLoan” and “postGradLoan” objects.