### PR TITLE
Prevent duplicates and add content to inform consumer a new test user…

### DIFF
--- a/resources/public/api/conf/1.0/docs/overview.md
+++ b/resources/public/api/conf/1.0/docs/overview.md
@@ -3,4 +3,8 @@ The Individuals Integration Framework Test Support API allows you to create test
 - Individuals Employments
 - Individuals Income
 - Individuals Benefits and Credits
-- Individuals Details
+- Individuals Contact Details
+
+This API does not accept duplicate entries. A unique User and Employment MUST be created prior to submitting
+employments, income, benefits and credits and contact details. This can be achieved
+via the `Create a Test User API`

--- a/test/it/uk/gov/hmrc/individualsifapistub/DetailsRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/DetailsRepositorySpec.scala
@@ -42,9 +42,8 @@ class DetailsRepositorySpec extends RepositoryTestHelper with TestHelpers {
 
       await(repository.collection.indexesManager.list()).find({ i =>
       {
-        i.name.contains("nino-trn") &&
-          i.key.exists(key => key._1 == "id.nino") &&
-          i.key.exists(key => key._1 == "id.trn")
+        i.name.contains("cache-key") &&
+          i.key.exists(key => key._1 == "details")
           i.background &&
           i.unique
       }
@@ -58,7 +57,7 @@ class DetailsRepositorySpec extends RepositoryTestHelper with TestHelpers {
     "create a details response with a nino" in {
 
       val ident = Identifier(Some(ninoValue), None, None, None, Some(useCase))
-      val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+      val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
 
       val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
 
@@ -71,7 +70,7 @@ class DetailsRepositorySpec extends RepositoryTestHelper with TestHelpers {
     "create a details response with a trn" in {
 
       val ident = Identifier(None, Some(trnValue), None, None, Some(useCase))
-      val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+      val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
 
       val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
 
@@ -79,6 +78,11 @@ class DetailsRepositorySpec extends RepositoryTestHelper with TestHelpers {
 
       result shouldBe detailsResponse
 
+    }
+
+    "fail to create duplicate" in {
+      await(repository.create("nino", ninoValue, useCase, request))
+      intercept[Exception](await(repository.create("nino", ninoValue, useCase, request)))
     }
 
   }
@@ -104,7 +108,7 @@ class DetailsRepositorySpec extends RepositoryTestHelper with TestHelpers {
     "return details when nino found" in {
 
       val ident = Identifier(Some(ninoValue), None, None, None, Some(useCase))
-      val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+      val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
 
       val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
 

--- a/test/it/uk/gov/hmrc/individualsifapistub/EmploymentRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/EmploymentRepositorySpec.scala
@@ -78,59 +78,49 @@ class EmploymentRepositorySpec extends RepositoryTestHelper {
 
     "have a unique index on nino and trn" in {
 
-      await(repository.collection.indexesManager.list()).find({ i => {
-        i.name.contains("nino-trn") &&
-          i.key.exists(key => key._1 == "id.nino") &&
-          i.key.exists(key => key._1 == "id.trn")
-          i.background &&
+      await(repository.collection.indexesManager.list()).find({ i =>
+      {
+        i.name.contains("cache-key") &&
+          i.key.exists(key => key._1 == "details")
+        i.background &&
           i.unique
       }
       }) should not be None
-
     }
   }
 
   "create" should {
 
     "create an employment with a nino" in {
-
       val result = await(repository.create("nino", nino, startDate, endDate, useCase, employments))
-
       result shouldBe employments
+    }
 
+    "fail to create duplicate" in {
+      await(repository.create("nino", nino, startDate, endDate, useCase, employments))
+      intercept[Exception](await(repository.create("nino", nino, startDate, endDate, useCase, employments)))
     }
 
     "create an employment with a trn" in {
-
       val result = await(repository.create("trn", trn, startDate, endDate, useCase, employments))
-
       result shouldBe employments
-
     }
   }
 
   "findByIdAndType" should {
 
     "return None when there are no details for a given nino" in {
-
       await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return None when there are no details for a given trn" in {
-
       await(repository.findByIdAndType("trn", trn, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return a single record with id" in {
-
       await(repository.create("nino", nino, startDate, endDate, useCase, employments))
-
       val result = await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields)))
-
       result.get shouldBe employments
-
     }
   }
 }

--- a/test/it/uk/gov/hmrc/individualsifapistub/IncomePayeRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/IncomePayeRepositorySpec.scala
@@ -45,10 +45,10 @@ class IncomePayeRepositorySpec
 
     "have a unique index on nino and trn" in {
 
-      await(repository.collection.indexesManager.list()).find({ i => {
-        i.name.contains("nino-trn") &&
-          i.key.exists(key => key._1 == "id.nino") &&
-          i.key.exists(key => key._1 == "id.trn")
+      await(repository.collection.indexesManager.list()).find({ i =>
+      {
+        i.name.contains("cache-key") &&
+          i.key.exists(key => key._1 == "details")
         i.background &&
           i.unique
       }
@@ -60,20 +60,21 @@ class IncomePayeRepositorySpec
   "create when type is nino" should {
 
     "create a paye record" in {
-
       val result = await(repository.create("nino", nino, startDate, endDate, useCase, request))
       result shouldBe request
+    }
 
+    "fail to create duplicate" in {
+      await(repository.create("nino", nino, startDate, endDate, useCase, request))
+      intercept[Exception](await(repository.create("nino", nino, startDate, endDate, useCase, request)))
     }
   }
 
   "create when type is trn" should {
 
     "create a paye" in {
-
       val result = await(repository.create("trn", trn, startDate, endDate, useCase, request))
       result shouldBe request
-
     }
 
   }
@@ -81,39 +82,26 @@ class IncomePayeRepositorySpec
   "find by id when type is Nino" should {
 
     "return None when there are no paye records for a given utr" in {
-
       await(repository.findByTypeAndId("nino", nino, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return the paye response" in {
-
       await(repository.create("nino", nino, startDate, endDate, useCase, request))
-
       val result = await(repository.findByTypeAndId("nino", nino, startDate, endDate, Some(fields)))
-
       result shouldBe Some(request)
-
     }
   }
 
   "find by id when type is trn" should {
 
     "return None when there are no paye records for a given utr" in {
-
       await(repository.findByTypeAndId("trn", trn, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return the paye response" in {
-
-
       await(repository.create("trn", trn, startDate, endDate, useCase, request))
-
       val result = await(repository.findByTypeAndId("trn", trn, startDate, endDate, Some(fields)))
-
       result shouldBe Some(request)
-
     }
   }
 }

--- a/test/it/uk/gov/hmrc/individualsifapistub/IncomeSaRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/IncomeSaRepositorySpec.scala
@@ -45,10 +45,10 @@ class IncomeSaRepositorySpec
 
     "have a unique index on nino and trn" in {
 
-      await(repository.collection.indexesManager.list()).find({ i => {
-        i.name.contains("nino-trn") &&
-          i.key.exists(key => key._1 == "id.nino") &&
-          i.key.exists(key => key._1 == "id.trn")
+      await(repository.collection.indexesManager.list()).find({ i =>
+      {
+        i.name.contains("cache-key") &&
+          i.key.exists(key => key._1 == "details")
         i.background &&
           i.unique
       }
@@ -60,11 +60,13 @@ class IncomeSaRepositorySpec
   "create when type is nino" should {
 
     "create a self assessment" in {
-
       val result = await(repository.create("nino", nino, startYear, endYear, useCase, request))
-
       result shouldBe request
+    }
 
+    "fail to create duplicate" in {
+      await(repository.create("nino", nino, startYear, endYear, useCase, request))
+      intercept[Exception](await(repository.create("nino", nino, startYear, endYear, useCase, request)))
     }
 
   }
@@ -72,30 +74,21 @@ class IncomeSaRepositorySpec
   "create when type is trn" should {
 
     "create a self assessment" in {
-
       val result = await(repository.create("trn", trn, startYear, endYear, useCase, request))
-
       result shouldBe request
-
     }
 
   }
 
   "find by id when type is nino" should {
     "return None when there are no self assessments" in {
-
       await(repository.findByTypeAndId("nino", nino, startYear, endYear, Some(fields))) shouldBe None
-
     }
 
     "return the self assessment" in {
-
       await(repository.create("nino", nino, startYear, endYear, useCase, request))
-
       val result = await(repository.findByTypeAndId("nino", nino, startYear, endYear, Some(fields)))
-
       result shouldBe Some(request)
-
     }
   }
 
@@ -103,20 +96,13 @@ class IncomeSaRepositorySpec
   "find by id when type is trn" should {
 
     "return None when there are no self assessments" in {
-
       await(repository.findByTypeAndId("trn", trn, startYear, endYear, Some(fields))) shouldBe None
-
     }
 
     "return the self assessment" in {
-
-
       await(repository.create("trn", trn, startYear, endYear, useCase, request))
-
       val result = await(repository.findByTypeAndId("trn", trn, startYear, endYear, Some(fields)))
-
       result shouldBe Some(request)
-
     }
   }
 }

--- a/test/it/uk/gov/hmrc/individualsifapistub/TaxCreditsRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/TaxCreditsRepositorySpec.scala
@@ -46,13 +46,12 @@ class TaxCreditsRepositorySpec extends RepositoryTestHelper {
     "have a unique index on nino and trn" in {
 
       await(repository.collection.indexesManager.list()).find({ i =>
-        {
-          i.name.contains("nino-trn") &&
-          i.key.exists(key => key._1 == "id.nino") &&
-          i.key.exists(key => key._1 == "id.trn")
-          i.background &&
+      {
+        i.name.contains("cache-key") &&
+          i.key.exists(key => key._1 == "details")
+        i.background &&
           i.unique
-        }
+      }
       }) should not be None
     }
 
@@ -61,19 +60,18 @@ class TaxCreditsRepositorySpec extends RepositoryTestHelper {
   "create" should {
 
     "create an application with a nino" in {
-
       val result = await(repository.create("nino", nino, startDate, endDate, useCase, applications))
-
       result shouldBe applications
+    }
 
+    "fail to create duplicate" in {
+      await(repository.create("nino", nino, startDate, endDate, useCase, applications))
+      intercept[Exception](await(repository.create("nino", nino, startDate, endDate, useCase, applications)))
     }
 
     "create an application with a trn" in {
-
       val result = await(repository.create("trn", trn, startDate, endDate, useCase, applications))
-
       result shouldBe applications
-
     }
 
   }
@@ -81,25 +79,17 @@ class TaxCreditsRepositorySpec extends RepositoryTestHelper {
   "findByIdAndType" should {
 
     "return None when there are no details for a given nino" in {
-
       await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return None when there are no details for a given trn" in {
-
       await(repository.findByIdAndType("trn", trn, startDate, endDate, Some(fields))) shouldBe None
-
     }
 
     "return a single record with id" in {
-
       await(repository.create("nino", nino, startDate, endDate, useCase, applications))
-
       val result = await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields)))
-
       result.get shouldBe applications
-
     }
   }
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/DetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/DetailsControllerSpec.scala
@@ -57,7 +57,7 @@ class DetailsControllerSpec extends TestSupport with TestHelpers {
     "Successfully create a details record and return created record as response" in new Setup {
 
       val ident = Identifier(Some(idValue), None, None, None, Some(useCase))
-      val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+      val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
       val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
 
       when(mockDetailsService.create(idType, idValue, useCase, request)).thenReturn(

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/EmploymentsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/EmploymentsControllerSpec.scala
@@ -89,7 +89,7 @@ class EmploymentsControllerSpec extends TestSupport {
 
   val employments = Employments(Seq(employment))
   val ident = Identifier(Some("XH123456A"), None, Some(startDate), Some(endDate), Some(useCase))
-  val id = s"${ident.nino.getOrElse(ident.trn)}-$startDate-$endDate-$useCase"
+  val id = s"${ident.nino.getOrElse(ident.trn.get)}-$startDate-$endDate-$useCase"
   val request = EmploymentEntry(id, Seq(employment))
 
   "Create Employment" should {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/DetailsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/DetailsServiceSpec.scala
@@ -56,7 +56,7 @@ class DetailsServiceSpec extends TestSupport with TestHelpers {
       "Return the created details when created with a NINO" in new Setup {
 
         val ident = Identifier(Some(idValue), None, None, None, Some(useCase))
-        val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+        val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
 
 
         val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
@@ -87,7 +87,7 @@ class DetailsServiceSpec extends TestSupport with TestHelpers {
       "Return details when successfully retrieved from mongo" in new Setup {
 
         val ident = Identifier(Some(idValue), None, None, None, Some(useCase))
-        val id = s"${ident.nino.getOrElse(ident.trn)}-$useCase"
+        val id = s"${ident.nino.getOrElse(ident.trn.get)}-$useCase"
 
         val detailsResponse = DetailsResponse(id, request.contactDetails, request.residences)
 

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/EmploymentsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/EmploymentsServiceSpec.scala
@@ -35,7 +35,7 @@ class EmploymentsServiceSpec extends TestSupport {
     val useCase = "TEST"
     val fields = "some(values)"
     val ident = Identifier(Some("XH123456A"), None, Some(startDate), Some(endDate), Some(useCase))
-    val id = s"${ident.nino.getOrElse(ident.trn)}-$startDate-$endDate-$useCase"
+    val id = s"${ident.nino.getOrElse(ident.trn.get)}-$startDate-$endDate-$useCase"
 
     val employment =
         Employment(

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/TaxCreditsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/TaxCreditsServiceSpec.scala
@@ -36,7 +36,7 @@ class TaxCreditsServiceSpec extends TestSupport {
     val useCase = "TEST"
     val fields = "some(values)"
     val ident = Identifier(Some(idValue), None, Some(startDate), Some(endDate), Some(useCase))
-    val id = s"${ident.nino.getOrElse(ident.trn)}-$startDate-$endDate-$useCase"
+    val id = s"${ident.nino.getOrElse(ident.trn.get)}-$startDate-$endDate-$useCase"
 
     val application: Application = Application(
       id = 12345,


### PR DESCRIPTION
… and employment must be created

New content added:

`This API does not accept duplicate entries. A unique User and Employment MUST be created prior to submitting employments, income, benefits and credits and contact details. This can be achieved via the Create a Test User API`