### PR TITLE
HODS-114 | Updated for Income and Employments

### DIFF
--- a/app/uk/gov/hmrc/individualsifapistub/controllers/EmploymentsController.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/controllers/EmploymentsController.scala
@@ -55,8 +55,9 @@ class EmploymentsController @Inject()(bodyParser: PlayBodyParsers,
                idValue: String,
                startDate: String,
                endDate: String,
-               fields: Option[String]): Action[AnyContent] = Action.async { implicit request =>
-    employmentsService.get(idType, idValue, startDate, endDate, fields) map {
+               fields: Option[String],
+               filter: Option[String]): Action[AnyContent] = Action.async { implicit request =>
+    employmentsService.get(idType, idValue, startDate, endDate, fields, filter) map {
       case Some(value) => Ok(Json.toJson(value))
       case None => {
         Ok(Json.parse("""{

--- a/app/uk/gov/hmrc/individualsifapistub/domain/Employments.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/domain/Employments.scala
@@ -33,7 +33,7 @@ case class Payment(date: Option[String],
                    week: Option[Int],
                    month: Option[Int])
 
-case class Employment(employer: Option[Employer], employment: Option[EmploymentDetail], payments: Option[Seq[Payment]])
+case class Employment(employer: Option[Employer], employerRef: Option[String], employment: Option[EmploymentDetail], payments: Option[Seq[Payment]])
 
 case class EmploymentEntry(id: String, employments: Seq[Employment])
 
@@ -131,11 +131,13 @@ object Employments {
   implicit val employmentFormat: Format[Employment] = Format(
     (
       (JsPath \ "employer").readNullable[Employer] and
+      (JsPath \ "employerRef").readNullable[String](minLength[String](1) keepAnd maxLength[String](14)) and
       (JsPath \ "employment").readNullable[EmploymentDetail] and
       (JsPath \ "payments").readNullable[Seq[Payment]]
     )(Employment.apply _),
     (
       (JsPath \ "employer").writeNullable[Employer] and
+      (JsPath \ "employerRef").writeNullable[String] and
       (JsPath \ "employment").writeNullable[EmploymentDetail] and
       (JsPath \ "payments").writeNullable[Seq[Payment]]
     )(unlift(Employment.unapply))

--- a/app/uk/gov/hmrc/individualsifapistub/repository/IncomeSaRepository.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/repository/IncomeSaRepository.scala
@@ -53,7 +53,9 @@ class IncomeSaRepository @Inject()(mongoConnectionProvider: MongoConnectionProvi
       "HMCTS-C2" -> "HMCTS-C2_HMCTS-C3",
       "HMCTS-C3" -> "HMCTS-C2_HMCTS-C3",
       "LSANI-C1" -> "LSANI-C1_LSANI-C3",
-      "LSANI-C3" -> "LSANI-C1_LSANI-C3"
+      "LSANI-C3" -> "LSANI-C1_LSANI-C3",
+      "RP2" -> "RP2_ECP",
+      "ECP" -> "RP2_ECP"
     )
 
     val ident = IdType.parse(idType) match {
@@ -90,7 +92,8 @@ class IncomeSaRepository @Inject()(mongoConnectionProvider: MongoConnectionProvi
       "sa(returnList(caseStartDate,income(foreign,foreignDivs,selfAssessment,selfEmployment,ukDivsAndInterest,ukInterest,ukProperty)),taxYear)" -> "HMCTS-C2_HMCTS-C3",
       "sa(returnList(address(line1,line2,line3,line4,postcode),businessDescription,caseStartDate,telephoneNumber),taxYear)" -> "HMCTS-C4",
       "sa(returnList(busEndDate,busStartDate,deducts(totalBusExpenses),income(allEmployments,foreign,foreignDivs,lifePolicies,other,partnerships,pensions,selfAssessment,selfEmployment,shares,trusts,ukDivsAndInterest,ukInterest,ukProperty),receivedDate,totalNIC,totalTaxPaid),taxYear)" -> "LSANI-C1_LSANI-C3",
-      "sa(returnList(address(line1,line2,line3,line4,postcode),businessDescription,caseStartDate,income(allEmployments,foreignDivs,lifePolicies,other,partnerships,pensions,selfAssessment,selfEmployment,shares,trusts,ukDivsAndInterest,ukInterest,ukProperty),receivedDate,telephoneNumber),taxYear)" -> "NICTSEJO-C4"
+      "sa(returnList(address(line1,line2,line3,line4,postcode),businessDescription,caseStartDate,income(allEmployments,foreignDivs,lifePolicies,other,partnerships,pensions,selfAssessment,selfEmployment,shares,trusts,ukDivsAndInterest,ukInterest,ukProperty),receivedDate,telephoneNumber),taxYear)" -> "NICTSEJO-C4",
+      "sa(returnList(income(allEmployments,other,selfAssessment,selfEmployment),receivedDate,utr),taxYear)" -> "RP2_ECP"
     )
 
     val ident = IdType.parse(idType) match {

--- a/app/uk/gov/hmrc/individualsifapistub/services/EmploymentsService.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/services/EmploymentsService.scala
@@ -50,7 +50,8 @@ class EmploymentsService @Inject()(employmentsRepository: EmploymentRepository,
           idValue: String,
           startDate: String,
           endDate: String,
-          fields: Option[String]): Future[Option[Employments]] = {
-    employmentsRepository.findByIdAndType(idType, idValue, startDate, endDate, fields)
+          fields: Option[String],
+          filter: Option[String]): Future[Option[Employments]] = {
+    employmentsRepository.findByIdAndType(idType, idValue, startDate, endDate, fields, filter)
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -9,7 +9,7 @@ GET     /individuals/tax-credits/:idType/:idValue                       uk.gov.h
 POST    /individuals/tax-credits/:idType/:idValue                       uk.gov.hmrc.individualsifapistub.controllers.TaxCreditsController.create(idType, idValue, startDate, endDate, useCase)
 
 # Employments
-GET     /individuals/employment/:idType/:idValue                       uk.gov.hmrc.individualsifapistub.controllers.EmploymentsController.retrieve(idType, idValue, startDate, endDate, fields: Option[String] ?= None)
+GET     /individuals/employment/:idType/:idValue                       uk.gov.hmrc.individualsifapistub.controllers.EmploymentsController.retrieve(idType, idValue, startDate, endDate, fields: Option[String] ?= None, filter: Option[String] ?= None)
 POST    /individuals/employment/:idType/:idValue                       uk.gov.hmrc.individualsifapistub.controllers.EmploymentsController.create(idType, idValue, startDate, endDate, useCase)
 
 # Details

--- a/resources/public/api/conf/1.0/examples/individuals/create-employment-response.json
+++ b/resources/public/api/conf/1.0/examples/individuals/create-employment-response.json
@@ -1,6 +1,7 @@
 {
   "employments": [
     {
+      "employerRef": "247/ZT6767895A",
       "payments": [
         {
           "date": "2019-01-31",

--- a/resources/public/api/conf/1.0/examples/individuals/create-employment.json
+++ b/resources/public/api/conf/1.0/examples/individuals/create-employment.json
@@ -1,6 +1,7 @@
 {
   "employments": [
     {
+      "employerRef": "247/ZT6767895A",
       "payments": [
         {
           "date": "2019-01-31",

--- a/resources/public/api/conf/1.0/schemas/individuals/create-employment.json
+++ b/resources/public/api/conf/1.0/schemas/individuals/create-employment.json
@@ -9,6 +9,12 @@
       "items": {
         "type": "object",
         "properties": {
+          "employerRef": {
+            "type": "string",
+            "example": "247/ZT6767895A",
+            "description": "Employer Reference - Made from \"districtNumber/schemeRef\"",
+            "pattern": "^[0-9]{3}[\/][a-zA-Z0-9]{1,10}$"
+          },
           "payments": {
             "description": "Payments made during the employment",
             "type": "array",

--- a/test/it/uk/gov/hmrc/individualsifapistub/EmploymentRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/EmploymentRepositorySpec.scala
@@ -44,6 +44,7 @@ class EmploymentRepositorySpec extends RepositoryTestHelper {
           districtNumber = Some("ABC"),
           schemeRef = Some("ABC")
         )),
+        employerRef = Some("247/ZT6767895A"),
         employment = Some(EmploymentDetail(
           startDate = Some("2001-12-31"),
           endDate = Some("2002-05-12"),
@@ -110,16 +111,16 @@ class EmploymentRepositorySpec extends RepositoryTestHelper {
   "findByIdAndType" should {
 
     "return None when there are no details for a given nino" in {
-      await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields))) shouldBe None
+      await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields), None)) shouldBe None
     }
 
     "return None when there are no details for a given trn" in {
-      await(repository.findByIdAndType("trn", trn, startDate, endDate, Some(fields))) shouldBe None
+      await(repository.findByIdAndType("trn", trn, startDate, endDate, Some(fields), None)) shouldBe None
     }
 
     "return a single record with id" in {
       await(repository.create("nino", nino, startDate, endDate, useCase, employments))
-      val result = await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields)))
+      val result = await(repository.findByIdAndType("nino", nino, startDate, endDate, Some(fields), None))
       result.get shouldBe employments
     }
   }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/EmploymentsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/EmploymentsControllerSpec.scala
@@ -76,6 +76,7 @@ class EmploymentsControllerSpec extends TestSupport {
           districtNumber = Some("ABC"),
           schemeRef = Some("ABC")
         )),
+        employerRef = Some("247/ZT6767895A"),
         employment = Some(EmploymentDetail(
           startDate = Some("2001-12-31"),
           endDate = Some("2002-05-12"),
@@ -202,11 +203,11 @@ class EmploymentsControllerSpec extends TestSupport {
 
     "Return employments when successfully retrieved from service" in new Setup {
 
-      when(mockEmploymentsService.get(idType, idValue, startDate, endDate, Some(fields))).thenReturn(
+      when(mockEmploymentsService.get(idType, idValue, startDate, endDate, Some(fields), None)).thenReturn(
         Future.successful(Some(employments))
       )
 
-      val result = await(underTest.retrieve(idType, idValue, startDate, endDate, Some(fields))(fakeRequest))
+      val result = await(underTest.retrieve(idType, idValue, startDate, endDate, Some(fields), None)(fakeRequest))
 
       status(result) shouldBe OK
 
@@ -216,12 +217,12 @@ class EmploymentsControllerSpec extends TestSupport {
 
     "fail when it cannot get from service" in new Setup {
 
-      when(mockEmploymentsService.get(idType, idValue, startDate, endDate, Some(fields))).thenReturn(
+      when(mockEmploymentsService.get(idType, idValue, startDate, endDate, Some(fields), None)).thenReturn(
         Future.failed(new Exception)
       )
 
       assertThrows[Exception] {
-        await(underTest.retrieve(idType, idValue, startDate, endDate, Some(fields))(fakeRequest))
+        await(underTest.retrieve(idType, idValue, startDate, endDate, Some(fields), None)(fakeRequest))
       }
 
     }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/EmploymentsSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/EmploymentsSpec.scala
@@ -66,6 +66,7 @@ class EmploymentsSpec extends UnitSpec with TestHelpers {
 
   val employment = Employment(
     employer = Some(employer),
+    employerRef = Some("247/ZT6767895A"),
     employment = Some(employmentDetail),
     payments = Some(Seq(payment))
   )
@@ -339,6 +340,7 @@ class EmploymentsSpec extends UnitSpec with TestHelpers {
           |      "districtNumber" : "ABC",
           |      "schemeRef" : "ABC"
           |    },
+          |    "employerRef" : "247/ZT6767895A",
           |    "employment" : {
           |      "startDate" : "2001-12-31",
           |      "endDate" : "2002-05-12",

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/EmploymentsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/EmploymentsServiceSpec.scala
@@ -58,6 +58,7 @@ class EmploymentsServiceSpec extends TestSupport {
             districtNumber = Some("ABC"),
             schemeRef = Some("ABC")
           )),
+          employerRef = Some("247/ZT6767895A"),
           employment = Some(EmploymentDetail(
             startDate = Some("2001-12-31"),
             endDate = Some("2002-05-12"),
@@ -130,22 +131,22 @@ class EmploymentsServiceSpec extends TestSupport {
 
       "Return employment when successfully retrieved from mongo" in new Setup {
 
-        when(mockEmploymentRepository.findByIdAndType(idType, idValue, startDate, endDate, Some(fields))).thenReturn(
+        when(mockEmploymentRepository.findByIdAndType(idType, idValue, startDate, endDate, Some(fields), None)).thenReturn(
           Future.successful(Some(employments))
         )
 
-        val response = await(underTest.get(idType, idValue, startDate, endDate, Some(fields)))
+        val response = await(underTest.get(idType, idValue, startDate, endDate, Some(fields), None))
 
         response shouldBe Some(employments)
 
       }
 
       "Return none if cannot be found in mongo" in new Setup {
-        when(mockEmploymentRepository.findByIdAndType(idType, idValue, startDate, endDate, Some(fields))).thenReturn(
+        when(mockEmploymentRepository.findByIdAndType(idType, idValue, startDate, endDate, Some(fields), None)).thenReturn(
           Future.successful(None)
         )
 
-        val response = await(underTest.get(idType, idValue, startDate, endDate, Some(fields)))
+        val response = await(underTest.get(idType, idValue, startDate, endDate, Some(fields), None))
 
         response shouldBe None
 


### PR DESCRIPTION
Added filter to employments, mappings for income use cases.
To test: confirm can save and retrieve data for all 4 use cases (employments RP2, ECP and income RP2, ECP).

- Get bearer token
- Create user (need API_PLATFORM_TEST_USER running locally)

POST http://localhost:9617/individuals
Accept: application/vnd.hmrc.1.0+json 
Content-Type: application/json
Body: JSON payload with following:
{
  "serviceNames": [
    "national-insurance",
    "self-assessment"
  ]
}

- Call "create" endpoints, inserting use case and NINO from previous step

POST http://localhost:8443/individuals/employment/nino/OR453462B?startDate=2017-01-01&endDate=2019-01-01&useCase=(ECP or RP2)
Content-Type: application/json
Body: JSON payload with employments data

- Call "get" endpoints, updating NINO from previous steps

Employments RP2: http://localhost:8443/individuals/employment/nino/OR453462B?startDate=2017-01-01&endDate=2019-01-01&fields=employments(employer(address(line1,line2,line3,line4,line5,postcode),name),employerRef,employment(endDate,startDate),payments(date,paidTaxablePay))&filter=employments[]/employer/employerRef eq '247/ZT6767895A'

Employments ECP: http://localhost:8443/individuals/employment/nino/OR453462B?startDate=2017-01-01&endDate=2019-01-01&fields=employments(employer(address(line1,line2,line3,line4,line5,postcode),name),employerRef,employment(endDate,startDate),payments(date,paidTaxablePay))

Repeat for income
