### PR TITLE
HODS-319 | Retrieve known facts from Test User data

### DIFF
--- a/app/uk/gov/hmrc/individualsifapistub/connector/ApiPlatformTestUserConnector.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/connector/ApiPlatformTestUserConnector.scala
@@ -40,6 +40,22 @@ class ApiPlatformTestUserConnector @Inject()(http : HttpClient, servicesConfig: 
       None
   }
 
+  def getOrganisationByCrn(crn: String)(implicit hc: HeaderCarrier): Future[Option[TestOrganisation]] = {
+    http.GET[TestOrganisation](s"$serviceUrl/organisations/crn/$crn") map (Some(_))
+  } recover {
+    case e: NotFoundException =>
+      Logger.warn(s"unable to retrieve employer with crn: $crn. ${e.getMessage}")
+      None
+  }
+
+  def getOrganisationBySaUtr(utr: String)(implicit hc: HeaderCarrier): Future[Option[TestIndividual]] = {
+    http.GET[TestIndividual](s"$serviceUrl/organisations/sautr/$utr") map (Some(_))
+  } recover {
+    case e: NotFoundException =>
+      Logger.warn(s"unable to retrieve individual with utr: $utr. ${e.getMessage}")
+      None
+  }
+
   def getIndividualByNino(nino: Nino)(implicit hc: HeaderCarrier): Future[TestIndividual] = {
     http.GET[TestIndividual](s"$serviceUrl/individuals/nino/${nino.value}")
   } recover {

--- a/app/uk/gov/hmrc/individualsifapistub/connector/ApiPlatformTestUserConnector.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/connector/ApiPlatformTestUserConnector.scala
@@ -44,7 +44,7 @@ class ApiPlatformTestUserConnector @Inject()(http : HttpClient, servicesConfig: 
     http.GET[TestOrganisation](s"$serviceUrl/organisations/crn/$crn") map (Some(_))
   } recover {
     case e: NotFoundException =>
-      Logger.warn(s"unable to retrieve employer with crn: $crn. ${e.getMessage}")
+      Logger.warn(s"unable to retrieve organisation with crn: $crn. ${e.getMessage}")
       None
   }
 
@@ -52,7 +52,7 @@ class ApiPlatformTestUserConnector @Inject()(http : HttpClient, servicesConfig: 
     http.GET[TestIndividual](s"$serviceUrl/organisations/sautr/$utr") map (Some(_))
   } recover {
     case e: NotFoundException =>
-      Logger.warn(s"unable to retrieve individual with utr: $utr. ${e.getMessage}")
+      Logger.warn(s"unable to retrieve organisation with utr: $utr. ${e.getMessage}")
       None
   }
 

--- a/app/uk/gov/hmrc/individualsifapistub/controllers/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/controllers/CommonController.scala
@@ -30,7 +30,6 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.bootstrap.backend.http.{ErrorResponse, JsonErrorHandler}
 import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
 import javax.inject.Inject
-import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -76,7 +75,7 @@ class CustomErrorHandler @Inject()( configuration: Configuration,
 abstract class CommonController(controllerComponents: ControllerComponents)
     extends BackendController(controllerComponents) {
 
-  protected val logger: Logger = play.api.Logger(this.getClass)
+  protected val logger: Logger = play.api.Logger(getClass)
 
   override protected def withJsonBody[T](f: (T) => Future[Result])(
       implicit request: Request[JsValue],

--- a/app/uk/gov/hmrc/individualsifapistub/controllers/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/controllers/CommonController.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.bootstrap.backend.http.{ErrorResponse, JsonErrorHandler}
 import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
 import javax.inject.Inject
+import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/app/uk/gov/hmrc/individualsifapistub/domain/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/domain/TestOrganisation.scala
@@ -22,6 +22,6 @@ case class TestAddress(line1: String, line2: String, postcode: String)
 
 case class TestOrganisationDetails(name: String, address: TestAddress)
 
-case class TestOrganisation(empRef: Option[EmpRef], organisationDetails: TestOrganisationDetails)
+case class TestOrganisation(empRef: Option[EmpRef], ctUtr: Option[String], crn: Option[String], organisationDetails: TestOrganisationDetails)
 
-case class TestIndividual(saUtr: Option[SaUtr])
+case class TestIndividual(saUtr: Option[SaUtr], taxpayerType: Option[String], organisationDetails: TestOrganisationDetails)

--- a/app/uk/gov/hmrc/individualsifapistub/domain/individuals/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/domain/individuals/JsonFormatters.scala
@@ -38,9 +38,10 @@ object JsonFormatters {
   implicit val createDetailsRequestFormat = Json.format[CreateDetailsRequest]
 
   implicit val testAddressFormat = Json.format[TestAddress]
-  implicit val testIndividualFormat = Json.format[TestIndividual]
   implicit val testOrganisationDetailsFormat = Json.format[TestOrganisationDetails]
   implicit val testOrganisationFormat = Json.format[TestOrganisation]
+  implicit val testIndividualFormat = Json.format[TestIndividual]
+
 
   implicit val errorInvalidRequestFormat = new Format[ErrorInvalidRequest] {
     def reads(json: JsValue): JsResult[ErrorInvalidRequest] = JsSuccess(

--- a/app/uk/gov/hmrc/individualsifapistub/domain/organisations/CorporationTaxCompanyDetails.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/domain/organisations/CorporationTaxCompanyDetails.scala
@@ -19,18 +19,33 @@ package uk.gov.hmrc.individualsifapistub.domain.organisations
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{Format, JsPath, Json}
+import uk.gov.hmrc.individualsifapistub.domain.{TestOrganisation, TestOrganisationDetails}
 
 case class Name(name1: String, name2: String)
-case class RegisteredDetails(name: Name, address: Address)
-case class CommunicationDetails(name: Name, address: Address)
-case class CreateCorporationTaxCompanyDetailsRequest(utr: String, crn: String, registeredDetails: Option[RegisteredDetails], communicationDetails: Option[CommunicationDetails])
-
-case class CorporationTaxCompanyDetailsResponse(utr: String, crn: String, registeredDetails: Option[RegisteredDetails], communicationDetails: Option[CommunicationDetails])
+case class NameAddressDetails(name: Name, address: Address)
+case class CorporationTaxCompanyDetails(utr: String, crn: String, registeredDetails: Option[NameAddressDetails], communicationDetails: Option[NameAddressDetails])
 
 object CorporationTaxCompanyDetails {
 
   val utrPattern = "^[0-9]{10}$".r
   val crnPattern = "^[A-Z0-9]{1,10}$".r
+
+  def fromApiPlatformTestUser(testUser: TestOrganisation): CorporationTaxCompanyDetails  = CorporationTaxCompanyDetails(
+    testUser.ctUtr.getOrElse(""),
+    testUser.crn.getOrElse(""),
+    registeredDetails = Some(fromOrganisationDetails(testUser.organisationDetails)),
+    communicationDetails = None
+  )
+
+  def fromOrganisationDetails(organisationDetails: TestOrganisationDetails): NameAddressDetails = NameAddressDetails(
+    Name(organisationDetails.name, ""),
+    Address(
+      Some(organisationDetails.address.line1),
+      Some(organisationDetails.address.line2),
+      None,
+      None,
+      Some(organisationDetails.address.postcode))
+  )
 
   implicit val nameFormat = Format[Name](
     (
@@ -60,61 +75,34 @@ object CorporationTaxCompanyDetails {
       )(unlift(Address.unapply))
   )
 
-  implicit val registeredDetailsFormat: Format[RegisteredDetails] = Format(
+  implicit val nameAddressDetailsFormat: Format[NameAddressDetails] = Format(
     (
       (JsPath \ "name").read[Name] and
         (JsPath \ "address").read[Address]
-      )(RegisteredDetails.apply _),
+      )(NameAddressDetails.apply _),
     (
       (JsPath \ "name").write[Name] and
         (JsPath \ "address").write[Address]
-      )(unlift(RegisteredDetails.unapply))
+      )(unlift(NameAddressDetails.unapply))
   )
 
-  implicit val communicationDetailsFormat: Format[CommunicationDetails] = Format(
-    (
-      (JsPath \ "name").read[Name] and
-        (JsPath \ "address").read[Address]
-      )(CommunicationDetails.apply _),
-    (
-      (JsPath \ "name").write[Name] and
-        (JsPath \ "address").write[Address]
-      )(unlift(CommunicationDetails.unapply))
-  )
-
-  implicit val createCorporationTaxCompanyDetailsRequestFormat: Format[CreateCorporationTaxCompanyDetailsRequest] = Format(
+  implicit val corporationTaxCompanyDetailsResponseFormat: Format[CorporationTaxCompanyDetails] = Format(
     (
       (JsPath \ "utr").read[String](pattern(utrPattern, "Invalid UTR format")) and
         (JsPath \ "crn").read[String](pattern(crnPattern, "Inavlid CRN format")) and
-        (JsPath \ "registeredDetails").readNullable[RegisteredDetails] and
-        (JsPath \ "communicationDetails").readNullable[CommunicationDetails]
-      )(CreateCorporationTaxCompanyDetailsRequest.apply _),
+        (JsPath \ "registeredDetails").readNullable[NameAddressDetails] and
+        (JsPath \ "communicationDetails").readNullable[NameAddressDetails]
+      )(CorporationTaxCompanyDetails.apply _),
     (
       (JsPath \ "utr").write[String] and
         (JsPath \ "crn").write[String] and
-        (JsPath \ "registeredDetails").writeNullable[RegisteredDetails] and
-        (JsPath \ "communicationDetails").writeNullable[CommunicationDetails]
-      )(unlift(CreateCorporationTaxCompanyDetailsRequest.unapply))
-  )
-
-  implicit val corporationTaxCompanyDetailsResponseFormat: Format[CorporationTaxCompanyDetailsResponse] = Format(
-    (
-      (JsPath \ "utr").read[String](pattern(utrPattern, "Invalid UTR format")) and
-        (JsPath \ "crn").read[String](pattern(crnPattern, "Inavlid CRN format")) and
-        (JsPath \ "registeredDetails").readNullable[RegisteredDetails] and
-        (JsPath \ "communicationDetails").readNullable[CommunicationDetails]
-      )(CorporationTaxCompanyDetailsResponse.apply _),
-    (
-      (JsPath \ "utr").write[String] and
-        (JsPath \ "crn").write[String] and
-        (JsPath \ "registeredDetails").writeNullable[RegisteredDetails] and
-        (JsPath \ "communicationDetails").writeNullable[CommunicationDetails]
-      )(unlift(CorporationTaxCompanyDetailsResponse.unapply))
+        (JsPath \ "registeredDetails").writeNullable[NameAddressDetails] and
+        (JsPath \ "communicationDetails").writeNullable[NameAddressDetails]
+      )(unlift(CorporationTaxCompanyDetails.unapply))
   )
 }
 
-case class CTCompanyDetailsEntry(id: String, response :CorporationTaxCompanyDetailsResponse)
+case class CTCompanyDetailsEntry(id: String, response :CorporationTaxCompanyDetails)
 object CTCompanyDetailsEntry {
-  import CorporationTaxCompanyDetails._
   implicit val ctCompanyDetailsEntryFormat = Json.format[CTCompanyDetailsEntry]
 }

--- a/app/uk/gov/hmrc/individualsifapistub/repository/organisations/CorporationTaxCompanyDetailsRepository.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/repository/organisations/CorporationTaxCompanyDetailsRepository.scala
@@ -23,7 +23,7 @@ import reactivemongo.api.commands.WriteResult
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.individualsifapistub.domain.DuplicateException
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{CTCompanyDetailsEntry, CorporationTaxCompanyDetailsResponse, CreateCorporationTaxCompanyDetailsRequest}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{CTCompanyDetailsEntry, CorporationTaxCompanyDetails}
 import uk.gov.hmrc.individualsifapistub.repository.MongoConnectionProvider
 import uk.gov.hmrc.mongo.ReactiveRepository
 
@@ -37,8 +37,8 @@ class CorporationTaxCompanyDetailsRepository @Inject()(mongoConnectionProvider: 
         Index(key = List("id" -> IndexType.Ascending), name = Some("id"), unique = true, background = true)
     )
 
-    def create(request: CreateCorporationTaxCompanyDetailsRequest) = {
-        val response = CorporationTaxCompanyDetailsResponse(request.utr, request.crn, request.registeredDetails, request.communicationDetails)
+    def create(request: CorporationTaxCompanyDetails) = {
+        val response = CorporationTaxCompanyDetails(request.utr, request.crn, request.registeredDetails, request.communicationDetails)
         val entry = CTCompanyDetailsEntry(request.crn, response)
 
         insert(entry) map (_ => response) recover {

--- a/app/uk/gov/hmrc/individualsifapistub/repository/organisations/SelfAssessmentTaxPayerRepository.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/repository/organisations/SelfAssessmentTaxPayerRepository.scala
@@ -22,8 +22,7 @@ import reactivemongo.api.commands.WriteResult
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.individualsifapistub.domain.DuplicateException
-import uk.gov.hmrc.individualsifapistub.domain.individuals.Applications
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{CreateSelfAssessmentTaxPayerRequest, SATaxPayerEntry, SelfAssessmentTaxPayerResponse}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{SATaxPayerEntry, SelfAssessmentTaxPayer}
 import uk.gov.hmrc.individualsifapistub.repository.MongoConnectionProvider
 import uk.gov.hmrc.mongo.ReactiveRepository
 
@@ -38,8 +37,8 @@ class SelfAssessmentTaxPayerRepository @Inject()(mongoConnectionProvider: MongoC
     Index(key = List("id" -> IndexType.Ascending), name = Some("id"), unique = true, background = true)
   )
 
-  def create(request: CreateSelfAssessmentTaxPayerRequest) = {
-    val response = SelfAssessmentTaxPayerResponse(request.utr, request.taxPayerType, request.taxPayerDetails)
+  def create(request: SelfAssessmentTaxPayer) = {
+    val response = SelfAssessmentTaxPayer(request.utr, request.taxPayerType, request.taxPayerDetails)
     val entry = SATaxPayerEntry(request.utr, response)
 
     insert(entry) map (_ => response) recover {

--- a/app/uk/gov/hmrc/individualsifapistub/services/organisations/CorporationTaxCompanyDetailsService.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/services/organisations/CorporationTaxCompanyDetailsService.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.individualsifapistub.services.organisations
 
 import javax.inject.Inject
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{CorporationTaxCompanyDetailsResponse, CreateCorporationTaxCompanyDetailsRequest}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.CorporationTaxCompanyDetails
 import uk.gov.hmrc.individualsifapistub.repository.organisations.CorporationTaxCompanyDetailsRepository
 
 import scala.concurrent.Future
 
 class CorporationTaxCompanyDetailsService @Inject()(repository: CorporationTaxCompanyDetailsRepository) {
 
-  def create(request: CreateCorporationTaxCompanyDetailsRequest): Future[CorporationTaxCompanyDetailsResponse] = repository.create(request)
+  def create(request: CorporationTaxCompanyDetails): Future[CorporationTaxCompanyDetails] = repository.create(request)
 
-  def get(crn: String): Future[Option[CorporationTaxCompanyDetailsResponse]] = repository.find(crn)
+  def get(crn: String): Future[Option[CorporationTaxCompanyDetails]] = repository.find(crn)
 }

--- a/app/uk/gov/hmrc/individualsifapistub/services/organisations/SelfAssessmentTaxPayerService.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/services/organisations/SelfAssessmentTaxPayerService.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsifapistub.services.organisations
 
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{CreateSelfAssessmentTaxPayerRequest, SelfAssessmentTaxPayerResponse}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.SelfAssessmentTaxPayer
 import uk.gov.hmrc.individualsifapistub.repository.organisations.SelfAssessmentTaxPayerRepository
 
 import javax.inject.Inject
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 
 class SelfAssessmentTaxPayerService @Inject()(repository: SelfAssessmentTaxPayerRepository) {
 
-  def create(request: CreateSelfAssessmentTaxPayerRequest): Future[SelfAssessmentTaxPayerResponse] = repository.create(request)
+  def create(request: SelfAssessmentTaxPayer): Future[SelfAssessmentTaxPayer] = repository.create(request)
 
-  def get(utr: String): Future[Option[SelfAssessmentTaxPayerResponse]] = repository.find(utr)
+  def get(utr: String): Future[Option[SelfAssessmentTaxPayer]] = repository.find(utr)
 }

--- a/test/it/uk/gov/hmrc/individualsifapistub/organisations/CorporationTaxCompanyDetailsRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/organisations/CorporationTaxCompanyDetailsRepositorySpec.scala
@@ -18,8 +18,8 @@ package it.uk.gov.hmrc.individualsifapistub.organisations
 
 import testUtils.RepositoryTestHelper
 import uk.gov.hmrc.individualsifapistub.domain.DuplicateException
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{AccountingPeriod, Address, CommunicationDetails, CorporationTaxCompanyDetailsResponse, CorporationTaxReturnDetailsResponse, CreateCorporationTaxCompanyDetailsRequest, CreateCorporationTaxReturnDetailsRequest, Name, RegisteredDetails}
-import uk.gov.hmrc.individualsifapistub.repository.organisations.{CorporationTaxCompanyDetailsRepository, CorporationTaxReturnDetailsRepository}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CorporationTaxCompanyDetails, Name, NameAddressDetails}
+import uk.gov.hmrc.individualsifapistub.repository.organisations.CorporationTaxCompanyDetailsRepository
 
 class CorporationTaxCompanyDetailsRepositorySpec extends RepositoryTestHelper  {
 
@@ -34,11 +34,11 @@ class CorporationTaxCompanyDetailsRepositorySpec extends RepositoryTestHelper  {
 
   val name = Name("Waitrose", "And Partners")
 
-  val registeredDetails = RegisteredDetails(name, address)
-  val communicationDetails = CommunicationDetails(name, address)
+  val registeredDetails = NameAddressDetails(name, address)
+  val communicationDetails = NameAddressDetails(name, address)
 
-  val request = CreateCorporationTaxCompanyDetailsRequest("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
-  val response = CorporationTaxCompanyDetailsResponse("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val request = CorporationTaxCompanyDetails("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val response = CorporationTaxCompanyDetails("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
 
   "collection" should {
     "have a unique index on a request's crn" in {

--- a/test/it/uk/gov/hmrc/individualsifapistub/organisations/SelfAssessmentTaxPayerRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/individualsifapistub/organisations/SelfAssessmentTaxPayerRepositorySpec.scala
@@ -18,7 +18,7 @@ package it.uk.gov.hmrc.individualsifapistub.organisations
 
 import testUtils.RepositoryTestHelper
 import uk.gov.hmrc.individualsifapistub.domain.DuplicateException
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CreateSelfAssessmentTaxPayerRequest, SelfAssessmentTaxPayerResponse, TaxPayerDetails}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, SelfAssessmentTaxPayer, TaxPayerDetails}
 import uk.gov.hmrc.individualsifapistub.repository.organisations.SelfAssessmentTaxPayerRepository
 
 class SelfAssessmentTaxPayerRepositorySpec extends RepositoryTestHelper  {
@@ -31,9 +31,9 @@ class SelfAssessmentTaxPayerRepositorySpec extends RepositoryTestHelper  {
                         Some("West midlands"),
                         Some("B14 6JH"))
 
-  val taxPayerDetails = Seq(TaxPayerDetails("John Smith II", "Registered", exampleAddress))
-  val request = CreateSelfAssessmentTaxPayerRequest("1234567890", "Individual", taxPayerDetails)
-  val response = SelfAssessmentTaxPayerResponse("1234567890", "Individual", taxPayerDetails)
+  val taxPayerDetails = Seq(TaxPayerDetails("John Smith II", Some("Registered"), exampleAddress))
+  val request = SelfAssessmentTaxPayer("1234567890", "Individual", taxPayerDetails)
+  val response = SelfAssessmentTaxPayer("1234567890", "Individual", taxPayerDetails)
 
   "collection" should {
     "have a unique index on a requests utr" in {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/ApiPlatformTestUserConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/ApiPlatformTestUserConnectorSpec.scala
@@ -25,7 +25,7 @@ import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND, OK}
 import uk.gov.hmrc.domain.{EmpRef, Nino, SaUtr}
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, NotFoundException}
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
-import uk.gov.hmrc.individualsifapistub.domain.{TestIndividual, _}
+import uk.gov.hmrc.individualsifapistub.domain._
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 class ApiPlatformTestUserConnectorSpec

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/DetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/DetailsControllerSpec.scala
@@ -48,17 +48,28 @@ class DetailsControllerSpec extends TestSupport with TestHelpers {
     val mockDetailsService = new DetailsService(detailsRepo, apiPlatformTestUserConnector, servicesConfig)
     val underTest = new DetailsController(bodyParsers, controllerComponents, mockDetailsService)
 
+
+    val idType = "nino"
+    val idValue = "XH123456A"
+    val startDate = "2020-01-01"
+    val endDate = "2020-21-31"
+    val useCase = "TEST"
+    val fields = "some(values)"
+    val utr = SaUtr("2432552635")
+
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
   }
 
-  val idType = "nino"
-  val idValue = "XH123456A"
-  val startDate = "2020-01-01"
-  val endDate = "2020-21-31"
-  val useCase = "TEST"
-  val fields = "some(values)"
-  val utr = SaUtr("2432552635")
 
   val request = CreateDetailsRequest(
     Some(Seq(ContactDetail(9, "MOBILE TELEPHONE", "07123 987654"), ContactDetail(9,"MOBILE TELEPHONE", "07123 987655"))),

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/EmploymentsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/EmploymentsControllerSpec.scala
@@ -48,8 +48,19 @@ class EmploymentsControllerSpec extends TestSupport {
     val mockEmploymentsService = new EmploymentsService(employmentsRepo, apiPlatformTestUserConnector, servicesConfig)
     val underTest = new EmploymentsController(bodyParsers, controllerComponents, mockEmploymentsService)
 
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
+    val utr = SaUtr("2432552635")
+
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
   }
 
   val idType = Nino.toString
@@ -58,7 +69,6 @@ class EmploymentsControllerSpec extends TestSupport {
   val endDate = "2020-21-31"
   val useCase = "TEST"
   val fields = "some(values)"
-  val utr = SaUtr("2432552635")
 
   implicit val cerFormat = Employments.createEmploymentEntryFormat
 

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/IncomeControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/IncomeControllerSpec.scala
@@ -26,10 +26,10 @@ import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
 import uk.gov.hmrc.individualsifapistub.controllers.individuals.IncomeController
+import uk.gov.hmrc.individualsifapistub.domain.{RecordNotFoundException, TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.individuals.IncomePaye._
 import uk.gov.hmrc.individualsifapistub.domain.individuals.IncomeSa._
 import uk.gov.hmrc.individualsifapistub.domain.individuals.{IncomePaye, IncomeSa}
-import uk.gov.hmrc.individualsifapistub.domain.{RecordNotFoundException, TestIndividual}
 import uk.gov.hmrc.individualsifapistub.repository.individuals.{IncomePayeRepository, IncomeSaRepository}
 import uk.gov.hmrc.individualsifapistub.services.individuals.IncomeService
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -50,8 +50,19 @@ class IncomeControllerSpec extends TestSupport with IncomeSaHelpers with IncomeP
     val incomeService = new IncomeService(incomeSaRepo, incomePayeRepo, apiPlatformTestUserConnector, servicesConfig)
     val underTest = new IncomeController(bodyParsers, controllerComponents, incomeService)
 
+    val utr = SaUtr("2432552635")
+
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
   }
 
   val idType = "nino"
@@ -62,7 +73,7 @@ class IncomeControllerSpec extends TestSupport with IncomeSaHelpers with IncomeP
   val endYear = "2020"
   val useCase = "TEST"
   val fields = "some(values)"
-  val utr = SaUtr("2432552635")
+
 
   val innerSaValue = Seq(createValidSaTaxYearEntry(), createValidSaTaxYearEntry())
   val incomeSaResponse = IncomeSa(Some(innerSaValue))

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/TaxCreditsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/individuals/TaxCreditsControllerSpec.scala
@@ -26,9 +26,9 @@ import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
 import uk.gov.hmrc.individualsifapistub.controllers.individuals.TaxCreditsController
+import uk.gov.hmrc.individualsifapistub.domain.{RecordNotFoundException, TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.individuals.TaxCredits._
 import uk.gov.hmrc.individualsifapistub.domain.individuals.{Application, Applications, Identifier}
-import uk.gov.hmrc.individualsifapistub.domain.{RecordNotFoundException, TestIndividual}
 import uk.gov.hmrc.individualsifapistub.repository.individuals.TaxCreditsRepository
 import uk.gov.hmrc.individualsifapistub.services.individuals.TaxCreditsService
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -48,7 +48,7 @@ class TaxCreditsControllerSpec extends TestSupport {
     val underTest = new TaxCreditsController(bodyParsers, controllerComponents, mockTaxCreditsService)
 
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
   }
 
   val application: Application = Application(
@@ -66,6 +66,15 @@ class TaxCreditsControllerSpec extends TestSupport {
   val useCase = "TEST"
   val fields = "some(values)"
   val utr = SaUtr("2432552635")
+
+  val testIndividual = TestIndividual(
+    saUtr = Some(utr),
+    taxpayerType = Some("Individual"),
+    organisationDetails = TestOrganisationDetails(
+      name = "Barry Barryson",
+      address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+    )
+  )
   val ident = Identifier(Some(idValue), None, Some(startDate), Some(endDate), Some(useCase))
 
   val request = Applications(Seq(application))

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/CorporationTaxCompanyDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/CorporationTaxCompanyDetailsControllerSpec.scala
@@ -110,15 +110,16 @@ class CorporationTaxCompanyDetailsControllerSpec extends TestSupport {
       })
     }
 
-    "fails when an entry cannot be found" in {
-      when(mockConnector.getOrganisationByCrn(any())(any())).thenReturn(Future.failed(new NotFoundException("NOT_FOUND")))
-      when(mockService.get(ctCompanyDetails.crn)).thenReturn(Future.failed(new Exception))
+    "fails when an exception is thrown" in {
+      when(mockConnector.getOrganisationByCrn(any())(any())).thenReturn(Future.failed(new Exception))
 
       val httpRequest =
         FakeRequest()
           .withMethod("GET")
 
-      assertThrows[Exception] { await(controller.retrieve(ctCompanyDetails.crn)(httpRequest)) }
+
+      val result = await(controller.retrieve(ctCompanyDetails.crn)(httpRequest))
+       status(result) shouldBe INTERNAL_SERVER_ERROR
     }
   }
 

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/CorporationTaxCompanyDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/CorporationTaxCompanyDetailsControllerSpec.scala
@@ -17,13 +17,19 @@
 package unit.uk.gov.hmrc.individualsifapistub.util.controllers.organisations
 
 import controllers.Assets._
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
+import uk.gov.hmrc.domain.EmpRef
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
+import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
 import uk.gov.hmrc.individualsifapistub.controllers.organisations.CorporationTaxCompanyDetailsController
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestOrganisation, TestOrganisationDetails}
+import uk.gov.hmrc.individualsifapistub.domain.individuals.JsonFormatters._
 import uk.gov.hmrc.individualsifapistub.domain.organisations.CorporationTaxCompanyDetails._
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CommunicationDetails, CorporationTaxCompanyDetailsResponse, CreateCorporationTaxCompanyDetailsRequest, Name, RegisteredDetails}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CorporationTaxCompanyDetails, Name, NameAddressDetails}
 import uk.gov.hmrc.individualsifapistub.repository.organisations.CorporationTaxCompanyDetailsRepository
 import uk.gov.hmrc.individualsifapistub.services.organisations.CorporationTaxCompanyDetailsService
 import unit.uk.gov.hmrc.individualsifapistub.util.TestSupport
@@ -33,8 +39,10 @@ import scala.concurrent.Future
 class CorporationTaxCompanyDetailsControllerSpec extends TestSupport {
 
   val mockService = mock[CorporationTaxCompanyDetailsService]
-  val controller = new CorporationTaxCompanyDetailsController(bodyParsers, controllerComponents, mockService)
+  val mockConnector = mock[ApiPlatformTestUserConnector]
+  val controller = new CorporationTaxCompanyDetailsController(bodyParsers, controllerComponents, mockService, mockConnector)
   val repository = fakeApplication.injector.instanceOf[CorporationTaxCompanyDetailsRepository]
+  implicit val hc = HeaderCarrier()
 
   val address = Address(
     Some("Alfie House"),
@@ -45,38 +53,39 @@ class CorporationTaxCompanyDetailsControllerSpec extends TestSupport {
 
   val name = Name("Waitrose", "And Partners")
 
-  val registeredDetails = RegisteredDetails(name, address)
-  val communicationDetails = CommunicationDetails(name, address)
+  val registeredDetails = NameAddressDetails(name, address)
+  val communicationDetails = NameAddressDetails(name, address)
 
-  val request = CreateCorporationTaxCompanyDetailsRequest("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
-  val response = CorporationTaxCompanyDetailsResponse("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val ctCompanyDetails = CorporationTaxCompanyDetails("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val testOrganisation = TestOrganisation(Some(EmpRef("1234567890", "")), Some("12345678"), Some(""),
+    TestOrganisationDetails(name.name1, TestAddress(address.line1.get, address.line2.get, address.postcode.get)))
 
   "create" should {
     "return response with created status when successful" in {
-      when(mockService.create(request)).thenReturn(Future.successful(response))
+      when(mockService.create(ctCompanyDetails)).thenReturn(Future.successful(ctCompanyDetails))
 
       val httpRequest =
         FakeRequest()
           .withMethod("Post")
-          .withBody(Json.toJson(request))
+          .withBody(Json.toJson(ctCompanyDetails))
 
-      val result = controller.create(response.crn)(httpRequest)
+      val result = controller.create(ctCompanyDetails.crn)(httpRequest)
 
       result.map(x => {
         x.header.status shouldBe CREATED
-        jsonBodyOf(x) shouldBe Json.toJson(response)
+        jsonBodyOf(x) shouldBe Json.toJson(ctCompanyDetails)
       })
     }
 
     "fail when invalid request provided" in {
-      when(mockService.create(request)).thenReturn(Future.successful(response))
+      when(mockService.create(ctCompanyDetails)).thenReturn(Future.successful(ctCompanyDetails))
 
       val httpRequest =
         FakeRequest()
           .withMethod("POST")
           .withBody(Json.parse("{}"))
 
-      val result = controller.create(response.crn)(httpRequest)
+      val result = controller.create(ctCompanyDetails.crn)(httpRequest)
 
       result.map(x => {
         x.header.status shouldBe BAD_REQUEST
@@ -86,28 +95,31 @@ class CorporationTaxCompanyDetailsControllerSpec extends TestSupport {
 
   "retrieve" should {
     "return response when entry found by service" in {
-      when(mockService.get(request.crn)).thenReturn(Future.successful(Some(response)))
+      when(mockService.get(ctCompanyDetails.crn)).thenReturn(Future.successful(Some(ctCompanyDetails)))
+      when(mockConnector.getOrganisationByCrn(any())(any())).thenReturn(Future.successful(Some(testOrganisation)))
 
       val httpRequest =
         FakeRequest()
           .withMethod("GET")
 
-      val result = controller.retrieve(request.crn)(httpRequest)
+      val result = controller.retrieve(ctCompanyDetails.crn)(httpRequest)
 
       result.map(x => {
         x.header.status shouldBe OK
-        jsonBodyOf(x) shouldBe Json.toJson(response)
+        jsonBodyOf(x) shouldBe Json.toJson(testOrganisation)
       })
     }
 
     "fails when an entry cannot be found" in {
-      when(mockService.get(request.crn)).thenReturn(Future.failed(new Exception))
+      when(mockConnector.getOrganisationByCrn(any())(any())).thenReturn(Future.failed(new NotFoundException("NOT_FOUND")))
+      when(mockService.get(ctCompanyDetails.crn)).thenReturn(Future.failed(new Exception))
 
       val httpRequest =
         FakeRequest()
           .withMethod("GET")
 
-      assertThrows[Exception] { await(controller.retrieve(request.crn)(httpRequest)) }
+      assertThrows[Exception] { await(controller.retrieve(ctCompanyDetails.crn)(httpRequest)) }
     }
   }
+
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/SelfAssessmentTaxPayerControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/controllers/organisations/SelfAssessmentTaxPayerControllerSpec.scala
@@ -111,15 +111,16 @@ class SelfAssessmentTaxPayerControllerSpec extends TestSupport {
       })
     }
 
-    "fails when an entry cannot be found" in {
+    "fails when an exception is thrown" in {
 
-      when(mockConnector.getOrganisationBySaUtr(any())(any())).thenReturn(Future.failed(new NotFoundException("NOT_FOUND")))
+      when(mockConnector.getOrganisationBySaUtr(any())(any())).thenReturn(Future.failed(new Exception))
 
       val httpRequest =
         FakeRequest()
           .withMethod("GET")
 
-      assertThrows[Exception] { await(controller.retrieve(selfAssessmentTaxPayer.utr)(httpRequest)) }
+      val result = await(controller.retrieve(selfAssessmentTaxPayer.utr)(httpRequest))
+      status(result) shouldBe INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/organisations/CorporationTaxCompanyDetailsSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/organisations/CorporationTaxCompanyDetailsSpec.scala
@@ -17,13 +17,15 @@
 package unit.uk.gov.hmrc.individualsifapistub.util.domain.organisations
 
 import play.api.libs.json.Json
+import uk.gov.hmrc.domain.EmpRef
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestOrganisation, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.organisations.CorporationTaxCompanyDetails._
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CommunicationDetails, CreateCorporationTaxCompanyDetailsRequest, Name, RegisteredDetails}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CorporationTaxCompanyDetails, Name, NameAddressDetails}
 import unit.uk.gov.hmrc.individualsifapistub.util.UnitSpec
 
 class CorporationTaxCompanyDetailsSpec extends UnitSpec {
 
-  "RegisteredDetails reads from JSON successfully" in {
+  "NameAddressDetails reads from JSON successfully" in {
     val json =
       """
         |{
@@ -41,7 +43,7 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
         |}
         |""".stripMargin
 
-    val expectedResult = RegisteredDetails(
+    val expectedResult = NameAddressDetails(
       Name("Waitrose", "And Partners"),
       Address(
         Some("Alfie House"),
@@ -52,48 +54,14 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
       )
     )
 
-    val result = Json.parse(json).validate[RegisteredDetails]
+    val result = Json.parse(json).validate[NameAddressDetails]
 
     result.isSuccess shouldBe true
     result.get shouldBe expectedResult
   }
 
-  "CommunicationDetails reads from JSON successfully" in {
-    val json =
-      """
-        |{
-        |    "name": {
-        |      "name1": "Waitrose",
-        |      "name2": "And Partners"
-        |    },
-        |    "address": {
-        |      "line1": "Alfie House",
-        |      "line2": "Main Street",
-        |      "line3": "Manchester",
-        |      "line4": "Londonberry",
-        |      "postcode": "LN1 1AG"
-        |    }
-        |}
-        |""".stripMargin
 
-    val expectedResult = CommunicationDetails(
-      Name("Waitrose", "And Partners"),
-      Address(
-        Some("Alfie House"),
-        Some("Main Street"),
-        Some("Manchester"),
-        Some("Londonberry"),
-        Some("LN1 1AG")
-      )
-    )
-
-    val result = Json.parse(json).validate[CommunicationDetails]
-
-    result.isSuccess shouldBe true
-    result.get shouldBe expectedResult
-  }
-
-  "RegisteredDetails reads from JSON unsuccessfully when address field is incorrect" in {
+  "NameAddressDetails reads from JSON unsuccessfully when address field is incorrect" in {
     val json =
       """
         |    {
@@ -111,12 +79,12 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
         |    }
         |""".stripMargin
 
-    val result = Json.parse(json).validate[RegisteredDetails]
+    val result = Json.parse(json).validate[NameAddressDetails]
 
     result.isSuccess shouldBe false
   }
 
-  "RegisteredDetails reads from JSON unsuccessfully when name field is incorrect" in {
+  "NameAddressDetails reads from JSON unsuccessfully when name field is incorrect" in {
     val json =
       """
         |    {
@@ -134,49 +102,9 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
         |    }
         |""".stripMargin
 
-    val result = Json.parse(json).validate[RegisteredDetails]
+    val result = Json.parse(json).validate[NameAddressDetails]
 
     result.isSuccess shouldBe true
-  }
-
-  "CommunicationDetails reads from JSON unsuccessfully when address field is incorrect" in {
-    val json =
-      """
-        |    {
-        |      "name": {
-        |         "name1": "Matty",
-        |         "name2": "Harris"
-        |        },
-        |       "address": {
-        |         "line1": 1,
-        |         "line2": "test2",
-        |         "line3": "test3",
-        |         "line4": "test4",
-        |         "postcode": "testPost"
-        |        }
-        |    }
-        |""".stripMargin
-
-    val result = Json.parse(json).validate[CommunicationDetails]
-
-    result.isSuccess shouldBe false
-  }
-
-  "CreateCorporationTaxCompanyDetailsRequest reads from JSON successfully" in {
-    val json =
-      """
-        |    {
-        |      "utr": "1234567890",
-        |      "crn": "12345678"
-        |    }
-        |""".stripMargin
-
-    val expectedResult = CreateCorporationTaxCompanyDetailsRequest("1234567890", "12345678", None, None)
-
-    val result = Json.parse(json).validate[CreateCorporationTaxCompanyDetailsRequest]
-
-    result.isSuccess shouldBe true
-    result.get shouldBe expectedResult
   }
 
   "CreateCorporationTaxCompanyDetailsRequest reads from JSON unsuccessfully when crn is incorrect" in {
@@ -188,7 +116,7 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
         |    }
         |""".stripMargin
 
-    val result = Json.parse(json).validate[CreateCorporationTaxCompanyDetailsRequest]
+    val result = Json.parse(json).validate[CorporationTaxCompanyDetails]
 
     result.isSuccess shouldBe false
   }
@@ -202,8 +130,40 @@ class CorporationTaxCompanyDetailsSpec extends UnitSpec {
         |    }
         |""".stripMargin
 
-    val result = Json.parse(json).validate[CreateCorporationTaxCompanyDetailsRequest]
+    val result = Json.parse(json).validate[CorporationTaxCompanyDetails]
 
     result.isSuccess shouldBe false
   }
+
+  "CreateCorporationTaxCompanyDetailsRequest converts successfully from TestOrganisation" in {
+    val empRef = EmpRef("123", "AI45678")
+    val testOrganisation = TestOrganisation(
+      Some(empRef),
+      Some("0123456789"),
+      Some("123456789"),
+      TestOrganisationDetails(
+        "Disney Inc",
+        TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")))
+
+    val expectedResult = CorporationTaxCompanyDetails(
+      "0123456789",
+      "123456789",
+      Some(NameAddressDetails(
+        Name("Disney Inc", ""),
+        Address(
+          Some("Capital Tower"),
+          Some("Aberdeen"),
+          None,
+          None,
+          Some("SW1 4DQ")
+        )
+      )),
+      None
+    )
+
+    val result = CorporationTaxCompanyDetails.fromApiPlatformTestUser(testOrganisation)
+
+    result shouldBe expectedResult
+  }
+
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/organisations/SelfAssessmentTaxPayerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/domain/organisations/SelfAssessmentTaxPayerSpec.scala
@@ -17,8 +17,10 @@
 package unit.uk.gov.hmrc.individualsifapistub.util.domain.organisations
 
 import play.api.libs.json.Json
+import uk.gov.hmrc.domain.SaUtr
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.organisations.SelfAssessmentTaxPayer._
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CreateSelfAssessmentTaxPayerRequest, TaxPayerDetails}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, SelfAssessmentTaxPayer, TaxPayerDetails}
 import unit.uk.gov.hmrc.individualsifapistub.util.UnitSpec
 
 class SelfAssessmentTaxPayerSpec extends UnitSpec {
@@ -47,7 +49,7 @@ class SelfAssessmentTaxPayerSpec extends UnitSpec {
         |}
         |""".stripMargin
 
-    val expectedResult = TaxPayerDetails("John Smith", "Individual", address)
+    val expectedResult = TaxPayerDetails("John Smith", Some("Individual"), address)
 
     val result = Json.parse(json).validate[TaxPayerDetails]
 
@@ -106,9 +108,9 @@ class SelfAssessmentTaxPayerSpec extends UnitSpec {
         |  "taxpayerDetails": []
         |}""".stripMargin
 
-    val expectedResult = CreateSelfAssessmentTaxPayerRequest("1234567890", "Individual", Seq.empty)
+    val expectedResult = SelfAssessmentTaxPayer("1234567890", "Individual", Seq.empty)
 
-    val result = Json.parse(json).validate[CreateSelfAssessmentTaxPayerRequest]
+    val result = Json.parse(json).validate[SelfAssessmentTaxPayer]
 
     result.isSuccess shouldBe true
     result.get shouldBe expectedResult
@@ -123,7 +125,7 @@ class SelfAssessmentTaxPayerSpec extends UnitSpec {
         |  "taxPayerDetails": []
         |}""".stripMargin
 
-    val result = Json.parse(json).validate[CreateSelfAssessmentTaxPayerRequest]
+    val result = Json.parse(json).validate[SelfAssessmentTaxPayer]
 
     result.isSuccess shouldBe false
   }
@@ -137,8 +139,42 @@ class SelfAssessmentTaxPayerSpec extends UnitSpec {
         |  "taxPayerDetails": []
         |}""".stripMargin
 
-    val result = Json.parse(json).validate[CreateSelfAssessmentTaxPayerRequest]
+    val result = Json.parse(json).validate[SelfAssessmentTaxPayer]
 
     result.isSuccess shouldBe false
   }
+
+  "Convert TaxPayerDetails from TestIndividual successfully" in {
+
+    val utr = SaUtr("2432552635")
+
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
+    val expectedResult = SelfAssessmentTaxPayer(
+      utr.utr,
+      "Individual",
+      Seq(TaxPayerDetails(
+        "Barry Barryson",
+        None,
+        Address(
+          Some("Capital Tower"),
+          Some("Aberdeen"),
+          None,
+          None,
+          Some("SW1 4DQ")
+      )))
+    )
+
+    val result = SelfAssessmentTaxPayer.fromApiPlatformTestUser(testIndividual)
+
+    result shouldBe expectedResult
+  }
+
 }

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/DetailsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/DetailsServiceSpec.scala
@@ -23,7 +23,7 @@ import testUtils.TestHelpers
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
-import uk.gov.hmrc.individualsifapistub.domain.TestIndividual
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.individuals._
 import uk.gov.hmrc.individualsifapistub.repository.individuals.DetailsRepository
 import uk.gov.hmrc.individualsifapistub.services.individuals.DetailsService
@@ -44,6 +44,16 @@ class DetailsServiceSpec extends TestSupport with TestHelpers {
     val fields = "some(values)"
     val utr = SaUtr("2432552635")
 
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
+
     val request = CreateDetailsRequest(
       Some(Seq(ContactDetail(9, "MOBILE TELEPHONE", "07123 987654"), ContactDetail(9,"MOBILE TELEPHONE", "07123 987655"))),
       Some(Seq(
@@ -59,7 +69,7 @@ class DetailsServiceSpec extends TestSupport with TestHelpers {
     val underTest = new DetailsService(mockDetailsRepository, apiPlatformTestUserConnector, servicesConfig)
 
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
 
   }
 

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/EmploymentsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/EmploymentsServiceSpec.scala
@@ -44,6 +44,15 @@ class EmploymentsServiceSpec extends TestSupport {
     val id = s"${ident.nino.getOrElse(ident.trn.get)}-$startDate-$endDate-$useCase"
     val utr = SaUtr("2432552635")
 
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
     val employment =
         Employment(
           employer = Some(Employer(
@@ -95,8 +104,7 @@ class EmploymentsServiceSpec extends TestSupport {
     val underTest = new EmploymentsService(mockEmploymentRepository, apiPlatformTestUserConnector, servicesConfig)
 
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
-
+      thenReturn(Future.successful(testIndividual))
   }
 
   "Employments Service" when {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/IncomeServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/IncomeServiceSpec.scala
@@ -22,7 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
-import uk.gov.hmrc.individualsifapistub.domain.TestIndividual
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.individuals.{IncomePaye, IncomeSa}
 import uk.gov.hmrc.individualsifapistub.repository.individuals.{IncomePayeRepository, IncomeSaRepository}
 import uk.gov.hmrc.individualsifapistub.services.individuals.IncomeService
@@ -51,6 +51,15 @@ class IncomeServiceSpec extends TestSupport with IncomeSaHelpers with IncomePaye
     val innerPayeValue = Seq(createValidPayeEntry(), createValidPayeEntry())
     val incomePayeResponse = IncomePaye(Some(innerPayeValue))
 
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
+
     implicit val hc = HeaderCarrier()
     val apiPlatformTestUserConnector = mock[ApiPlatformTestUserConnector]
 
@@ -62,7 +71,7 @@ class IncomeServiceSpec extends TestSupport with IncomeSaHelpers with IncomePaye
     )
 
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
   }
 
   "Income Service" when {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/TaxCreditsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/individuals/TaxCreditsServiceSpec.scala
@@ -22,7 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsifapistub.connector.ApiPlatformTestUserConnector
-import uk.gov.hmrc.individualsifapistub.domain.TestIndividual
+import uk.gov.hmrc.individualsifapistub.domain.{TestAddress, TestIndividual, TestOrganisationDetails}
 import uk.gov.hmrc.individualsifapistub.domain.individuals.{Application, Applications, Identifier}
 import uk.gov.hmrc.individualsifapistub.repository.individuals.TaxCreditsRepository
 import uk.gov.hmrc.individualsifapistub.services.individuals.TaxCreditsService
@@ -43,6 +43,14 @@ class TaxCreditsServiceSpec extends TestSupport {
     val ident = Identifier(Some(idValue), None, Some(startDate), Some(endDate), Some(useCase))
     val id = s"${ident.nino.getOrElse(ident.trn.get)}-$startDate-$endDate-$useCase"
     val utr = SaUtr("2432552635")
+    val testIndividual = TestIndividual(
+      saUtr = Some(utr),
+      taxpayerType = Some("Individual"),
+      organisationDetails = TestOrganisationDetails(
+        name = "Barry Barryson",
+        address = TestAddress("Capital Tower", "Aberdeen", "SW1 4DQ")
+      )
+    )
 
     val application: Application = Application(
       id = Some(12345),
@@ -61,7 +69,7 @@ class TaxCreditsServiceSpec extends TestSupport {
     val underTest = new TaxCreditsService(taxCreditsRepository, apiPlatformTestUserConnector, servicesConfig)
 
     when(apiPlatformTestUserConnector.getIndividualByNino(any())(any())).
-      thenReturn(Future.successful(TestIndividual(Some(utr))))
+      thenReturn(Future.successful(testIndividual))
 
   }
 

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/organisations/CorporationTaxCompanyDetailsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/organisations/CorporationTaxCompanyDetailsServiceSpec.scala
@@ -19,7 +19,7 @@ package unit.uk.gov.hmrc.individualsifapistub.util.services.organisations
 import org.mockito.Mockito.when
 import org.scalatest.{AsyncWordSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CommunicationDetails, CorporationTaxCompanyDetailsResponse, CreateCorporationTaxCompanyDetailsRequest, Name, RegisteredDetails}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CorporationTaxCompanyDetails, Name, NameAddressDetails}
 import uk.gov.hmrc.individualsifapistub.repository.organisations.CorporationTaxCompanyDetailsRepository
 import uk.gov.hmrc.individualsifapistub.services.organisations.CorporationTaxCompanyDetailsService
 
@@ -39,11 +39,11 @@ class CorporationTaxCompanyDetailsServiceSpec extends AsyncWordSpec with Matcher
 
   val name = Name("Waitrose", "And Partners")
 
-  val registeredDetails = RegisteredDetails(name, address)
-  val communicationDetails = CommunicationDetails(name, address)
+  val registeredDetails = NameAddressDetails(name, address)
+  val communicationDetails = NameAddressDetails(name, address)
 
-  val request = CreateCorporationTaxCompanyDetailsRequest("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
-  val response = CorporationTaxCompanyDetailsResponse("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val request = CorporationTaxCompanyDetails("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
+  val response = CorporationTaxCompanyDetails("1234567890", "12345678", Some(registeredDetails), Some(communicationDetails))
 
 
   "create" should {

--- a/test/unit/uk/gov/hmrc/individualsifapistub/util/services/organisations/SelfAssessmentTaxPayerServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsifapistub/util/services/organisations/SelfAssessmentTaxPayerServiceSpec.scala
@@ -19,9 +19,9 @@ package unit.uk.gov.hmrc.individualsifapistub.util.services.organisations
 import org.mockito.Mockito.when
 import org.scalatest.{AsyncWordSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
-import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, CreateSelfAssessmentReturnDetailRequest, CreateSelfAssessmentTaxPayerRequest, SelfAssessmentReturnDetailResponse, SelfAssessmentTaxPayerResponse, TaxPayerDetails, TaxYear}
-import uk.gov.hmrc.individualsifapistub.repository.organisations.{SelfAssessmentReturnDetailRepository, SelfAssessmentTaxPayerRepository}
-import uk.gov.hmrc.individualsifapistub.services.organisations.{SelfAssessmentReturnDetailService, SelfAssessmentTaxPayerService}
+import uk.gov.hmrc.individualsifapistub.domain.organisations.{Address, SelfAssessmentTaxPayer, TaxPayerDetails}
+import uk.gov.hmrc.individualsifapistub.repository.organisations.SelfAssessmentTaxPayerRepository
+import uk.gov.hmrc.individualsifapistub.services.organisations.SelfAssessmentTaxPayerService
 
 import scala.concurrent.Future
 
@@ -36,9 +36,9 @@ class SelfAssessmentTaxPayerServiceSpec extends AsyncWordSpec with Matchers with
     Some("West midlands"),
     Some("B14 6JH"))
 
-  val taxPayerDetails = Seq(TaxPayerDetails("John Smith II", "Registered", exampleAddress))
-  val request = CreateSelfAssessmentTaxPayerRequest("1234567890", "Individual", taxPayerDetails)
-  val response = SelfAssessmentTaxPayerResponse("1234567890", "Individual", taxPayerDetails)
+  val taxPayerDetails = Seq(TaxPayerDetails("John Smith II", Some("Registered"), exampleAddress))
+  val request = SelfAssessmentTaxPayer("1234567890", "Individual", taxPayerDetails)
+  val response = SelfAssessmentTaxPayer("1234567890", "Individual", taxPayerDetails)
 
   "create" should {
     "return response when creating" in {


### PR DESCRIPTION
I've tested the stub using postman - it should also be tested via organisations-matching-api.
If testing locally, requires starting the service `API_PLATFORM_TEST_USER`
CT endpoints require an organisation created using API_PLATFORM_TEST_USER with
```
 "serviceNames": [
    "corporation-tax"
  ]
```
SA endpoints require an organisation created using API_PLATFORM_TEST_USER with
```
 "serviceNames": [
    "self-assessment"
  ]
```
