### PR TITLE
DLS-7096 Document and configure postedDate

### DIFF
--- a/app/uk/gov/hmrc/individualsifapistub/repository/individuals/TaxCreditsRepository.scala
+++ b/app/uk/gov/hmrc/individualsifapistub/repository/individuals/TaxCreditsRepository.scala
@@ -96,13 +96,13 @@ class TaxCreditsRepository @Inject()(mongo: MongoComponent)(implicit val ec: Exe
                       fields: Option[String]): Future[Option[Applications]] = {
 
     def fieldsMap = Map(
-      "applications(awards(childTaxCredit(childCareAmount),payProfCalcDate,payments(amount,endDate,frequency,startDate,tcType),totalEntitlement,workingTaxCredit(amount,paidYTD)))" ->
+      "applications(awards(childTaxCredit(childCareAmount),payProfCalcDate,payments(amount,endDate,frequency,startDate,postedDate,tcType),totalEntitlement,workingTaxCredit(amount,paidYTD)))" ->
         "LAA-C1_LAA-C2_LAA-C3_working-tax-credit",
-      "applications(awards(childTaxCredit(babyAmount,childCareAmount,ctcChildAmount,familyAmount,paidYTD),payProfCalcDate,payments(amount,endDate,frequency,startDate,tcType),totalEntitlement))" ->
+      "applications(awards(childTaxCredit(babyAmount,childCareAmount,ctcChildAmount,familyAmount,paidYTD),payProfCalcDate,payments(amount,endDate,frequency,startDate,postedDate,tcType),totalEntitlement))" ->
         "LAA-C1_LAA-C2_LAA-C3_child-tax-credit",
-      "applications(awards(childTaxCredit(childCareAmount),payProfCalcDate,payments(amount,endDate,frequency,startDate,tcType),totalEntitlement,workingTaxCredit(amount,paidYTD)),id)" ->
+      "applications(awards(childTaxCredit(childCareAmount),payProfCalcDate,payments(amount,endDate,frequency,postedDate,startDate,tcType),totalEntitlement,workingTaxCredit(amount,paidYTD)),id)" ->
         "HMCTS-C2_HMCTS-C3_LSANI-C1_LSANI-C3_working-tax-credit",
-      "applications(awards(childTaxCredit(babyAmount,childCareAmount,ctcChildAmount,familyAmount,paidYTD),payProfCalcDate,payments(amount,endDate,frequency,startDate,tcType),totalEntitlement),id)" ->
+      "applications(awards(childTaxCredit(babyAmount,childCareAmount,ctcChildAmount,familyAmount,paidYTD),payProfCalcDate,payments(amount,endDate,frequency,postedDate,startDate,tcType),totalEntitlement),id)" ->
         "HMCTS-C2_HMCTS-C3_LSANI-C1_LSANI-C3_child-tax-credit"
     )
 

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1001,11 +1001,13 @@ paths:
                             payments:
                               - startDate: 1996-01-01
                                 endDate: 1996-03-01
+                                postedDate: 1996-04-01
                                 frequency: 7
                                 tcType: ETC
                                 amount: 76.34
                               - startDate: 1996-01-01
                                 endDate: 1996-03-01
+                                postedDate: 1996-04-01
                                 frequency: 7
                                 tcType: ICC
                                 amount: 76.34
@@ -1027,11 +1029,13 @@ paths:
                         payments:
                           - startDate: 1996-01-01
                             endDate: 1996-03-01
+                            postedDate: 1996-04-01
                             frequency: 7
                             tcType: ETC
                             amount: 76.34
                           - startDate: 1996-01-01
                             endDate: 1996-03-01
+                            postedDate: 1996-04-01
                             frequency: 7
                             tcType: ICC
                             amount: 76.34
@@ -1063,11 +1067,13 @@ paths:
                               payments:
                                 - startDate: 1996-01-01
                                   endDate: 1996-03-01
+                                  postedDate: 1996-04-01
                                   frequency: 7
                                   tcType: ETC
                                   amount: 76.34
                                 - startDate: 1996-01-01
                                   endDate: 1996-03-01
+                                  postedDate: 1996-04-01
                                   frequency: 7
                                   tcType: ICC
                                   amount: 76.34
@@ -1089,11 +1095,13 @@ paths:
                           payments:
                             - startDate: 1996-01-01
                               endDate: 1996-03-01
+                              postedDate: 1996-04-01
                               frequency: 7
                               tcType: ETC
                               amount: 76.34
                             - startDate: 1996-01-01
                               endDate: 1996-03-01
+                              postedDate: 1996-04-01
                               frequency: 7
                               tcType: ICC
                               amount: 76.34
@@ -2591,6 +2599,10 @@ components:
           type: string
           description: The end date of the payment.
           example: 1996-08-07
+        postedDate:
+          type: string
+          description: The end date of the payment.
+          example: 1996-08-18
         frequency:
           type: integer
           description: The number of days between payments. Currently supported values are 1, 7, 14, and 28.

--- a/resources/public/api/conf/1.0/examples/individuals/create-benefits-and-credits-response.json
+++ b/resources/public/api/conf/1.0/examples/individuals/create-benefits-and-credits-response.json
@@ -21,6 +21,7 @@
             {
               "startDate": "1996-01-01",
               "endDate": "1996-03-01",
+              "postedDate": "1996-04-01",
               "frequency": 7,
               "tcType": "ETC",
               "amount": 76.34
@@ -28,6 +29,7 @@
             {
               "startDate": "1996-01-01",
               "endDate": "1996-03-01",
+              "postedDate": "1996-04-01",
               "frequency": 7,
               "tcType": "ICC",
               "amount": 76.34

--- a/resources/public/api/conf/1.0/examples/individuals/create-benefits-and-credits.json
+++ b/resources/public/api/conf/1.0/examples/individuals/create-benefits-and-credits.json
@@ -21,6 +21,7 @@
             {
               "startDate": "1996-01-01",
               "endDate": "1996-03-01",
+              "postedDate": "1996-04-01",
               "frequency": 7,
               "tcType": "ETC",
               "amount": 76.34
@@ -28,6 +29,7 @@
             {
               "startDate": "1996-01-01",
               "endDate": "1996-03-01",
+              "postedDate": "1996-04-01",
               "frequency": 7,
               "tcType": "ICC",
               "amount": 76.34

--- a/resources/public/api/conf/1.0/schemas/individuals/create-benefits-and-credits-response.json
+++ b/resources/public/api/conf/1.0/schemas/individuals/create-benefits-and-credits-response.json
@@ -95,6 +95,12 @@
                         "description": "The end date of the payment.",
                         "example": "1996-08-07"
                       },
+                      "postedDate": {
+                        "type": "string",
+                        "id": "full-date",
+                        "description": "The end date of the payment.",
+                        "example": "1996-08-17"
+                      },
                       "frequency": {
                         "type": "integer",
                         "description": "The number of days between payments. Currently supported values are 1, 7, 14, and 28.",

--- a/resources/public/api/conf/1.0/schemas/individuals/create-benefits-and-credits.json
+++ b/resources/public/api/conf/1.0/schemas/individuals/create-benefits-and-credits.json
@@ -95,6 +95,12 @@
                         "description": "The end date of the payment.",
                         "example": "1996-08-07"
                       },
+                      "postedDate": {
+                        "type": "string",
+                        "id": "full-date",
+                        "description": "The end date of the payment.",
+                        "example": "1996-08-17"
+                      },
                       "frequency": {
                         "type": "integer",
                         "description": "The number of days between payments. Currently supported values are 1, 7, 14, and 28.",


### PR DESCRIPTION
[Ticket](https://jira.tools.tax.service.gov.uk/browse/DLS-7096)

`postedDate` was already implemented here, just not documented and wouldn't be allowed through the API gateway (maybe)