### PR TITLE
DLS-8997 | Config warnings fix, provide defaults in application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,7 +139,15 @@ mongodb {
     uri = "mongodb://localhost:27017/individuals-if-api-stub"
 }
 
-api.access.version-1.0 {}
+api {
+  access {
+    version-1.0 {
+      status = "BETA"
+      endpointsEnabled = true
+      whitelistedApplicationIds = []
+    }
+  }
+}
 
 microservice {
   metrics {


### PR DESCRIPTION
Config warning seems to be more strict abt specific fields than the parent block being empty. So, explicitly setting defaults for the fields config warnings have been reported on. 